### PR TITLE
SC-93 tso500 vep

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -56,6 +56,11 @@ Annotate against specified refseq transcripts with
 __This app uses the follow tools which are app assets:__
 * htslib (v1.14)
 * bedtools (v2.30.0)
+
+## What are the optional inputs for this app?
+- buffer_size [default = 500] : to allow for parallelisation the app recognised the instance type and splits annotation in the amount of available cores. The buffer size is the amount of variants VEP will annotate per core.
+
+> For larger vcfs please consider about the appropriate  instance type and buffer size to use.
 ## What does this app output?
 - Annotated vcf with the specified fields mentioned above.
 

--- a/Readme.md
+++ b/Readme.md
@@ -21,6 +21,7 @@ Annotate against specified refseq transcripts with
 - ClinVar
 - ClinVar - Clinical Indication
 - ClinVar - Clinical Significance
+- Cosmic Coding & Non-Coding
 - Transcript Feature
 
 ## What data are required for this app to run?
@@ -41,7 +42,7 @@ Annotate against specified refseq transcripts with
   - Cosmic NonCoding Variants VCF (v94)
       - CosmicNonCodingVariants_v94_grch37.normal.vcf.gz
       - CosmicNonCodingVariants_v94_grch37.normal.vcf.gz.tbi
-  - ClinVar VCF (2021113)
+  - ClinVar VCF (20211113)
       - clinvar_20211113_withChr.vcf.gz
       - clinvar_20211113_withChr.vcf.gz.tbi
   - CADD (v1.6)

--- a/Readme.md
+++ b/Readme.md
@@ -64,7 +64,6 @@ __This app uses the follow tools which are app assets:__
 ## What does this app output?
 - Annotated vcf with the specified fields mentioned above.
 
-## Limitations
+## Notes
 - Designed to be used as part of Helios workflow for processing Solid Cancer data for GRCh37 so all defaults are based on that.
-- This app uses a buffer_size of 500 variants and parallelised using 4 cores. This was chosen with the solid cancer vcfs in mind and may need to be tweaked or changed for bigger vcfs.
-
+- This app uses a buffer_size of 500 variants and parallelised the maximum number of cores available.As a default this app runs using mem1_ssd2_v2_x4 which translates to 4 cores. This was chosen with the solid cancer vcfs in mind as mentioned in the inputs section the buffer size can be given as an argument and the instance changed at runtime.

--- a/Readme.md
+++ b/Readme.md
@@ -1,59 +1,66 @@
-# eggd vep
+# eggd_vep
 
 ## What does this app do?
-### This app uses bedtools, bcftools and VEP to take VCFs from sentieon mutect2 and:
-- Annotates and filters the sentieon mutect2 VCF
+
+Annotates a vcf using [Variant Effect Predictor](https://github.com/Ensembl/ensembl-vep). Default docker image used v104.3.
 
 ## What are typical use cases for this app?
-### This app uses the follow tools which are app assets:
-* bcftools (v1.12)
-* bedtools (v2.30.0)
+This app was designed to annotate vcfs with specified fields. 
 
-### This app uses the following provided as inputs (these are all actually bundled into a single "VEP_tarball"):
-* VEP (v103.1) (docker image)
-* VEP refseq (v103) annotation sources
-* CADD (v1.6) which now includes splicing
-* ClinVar VCF (20210501 release) modified to add chr prefix
-* 138 merge VCF containing counts of each variant detected in first 138 samples
-
-### This app has access to the Internet
+Annotate against specified refseq transcripts with
+- gene symbol
+- variant class
+- variant consequence
+- exon number
+- HGVS c.
+- HGVS p.
+- gnomAD AF
+- gnomADg AF (genomes)
+- CADD PHRED
+- dbSNP
+- ClinVar
+- ClinVar - Clinical Indication
+- ClinVar - Clinical Significance
+- Transcript Feature
+   
 
 ## What data are required for this app to run?
-- VCF output from sentieon mutect2 as part of Uranus workflow
-- BED file that details ROIs for myeloid NGS panel (default specified)
-- Genome FASTA and index that was used by to generate the VCF (default specified)
-- VEP tarball consisting of VEP docker, plugins and annotation sources (default specified)
+- An input vcf to annotate
+- VEP docker image (`vep_docker`)
+- VEP plugins (`vep_plugins`)
+    - CADD.pm
+    - plugin_config.txt
+- VEP reference files (`vep_refs`):
+    - Homo_sapiens.GRCh37.dna.toplevel.fa.gz
+    - Homo_sapiens.GRCh37.dna.toplevel.fa.gz.fai
+    - Homo_sapiens.GRCh37.dna.toplevel.fa.gz.gzi
+    - homo_sapiens_refseq_vep_104_GRCh37.tar.gz
+* VEP annotation sources (`vep_annotation`):
+   - Cosmic Coding Variants VCF (v94)
+      - CosmicCodingMuts_v94_grch37.normal.vcf.gz
+      - CosmicCodingMuts_v94_grch37.normal.vcf.gz.tbi
+  - Cosmic NonCoding Variants VCF (v94)
+      - CosmicNonCodingVariants_v94_grch37.normal.vcf.gz
+      - CosmicNonCodingVariants_v94_grch37.normal.vcf.gz.tbi
+  - ClinVar VCF (20211002)
+      - clinvar_20211113_withChr.vcf.gz
+      - clinvar_20211113_withChr.vcf.gz.tbi
+  - CADD (v1.6)
+      - gnomad.genomes.r2.0.1.sites.noVEP.vcf.gz
+      - gnomad.genomes.r2.0.1.sites.noVEP.vcf.gz.tbi
+      - cadd_whole_genome_SNVs_GRCh37.tsv.gz
+      - cadd_whole_genome_SNVs_GRCh37.tsv.gz.tbi
+  
+  
+> All the annotation sources above are specific for GRCh37 and are set us default for the app - this app can run with the equivalent annotation sources for GRCh38.
 
+__This app uses the follow tools which are app assets:__
+* htslib (v1.14)
+* bedtools (v2.30.0)
 ## What does this app output?
-- Filtered and annotated VCF
-
-## How does this app work?
-- Filters VCF with bedtools:
-    - retain variants within ROI
-- Filters VCF with bcftools:
-    - retain positions where at least one variant has AF > 0.03
-    - retain positions where DP >99
-    - split multiallelics using `--keep-sum AD` which changes the ref AD to be the sum of AD's
-    - split multiallelics requires fixing AD and RPA number field in header from `.` to `R`
-- Annotates VCF with VEP:
-    - Annotate against specified refseq transcripts with
-        - gene symbol
-        - variant class
-        - variant consequence
-        - exon number
-        - HGVS c. & p.
-        - gnomAD AF
-        - SIFT
-        - PolyPhen
-        - dbSNP
-        - COSMIC
-        - ClinVar
-        - CADD
-        - previous counts
-- Filters VCF with VEP:
-    - Retain variants with gnomAD AF < 0.1
-    - Remove synonymous variants
+- Annotated vcf with the specified fields mentioned above.
 
 ## Limitations
-- Designed to be used as part of Uranus workflow for processing myeloid NGS panel
-- When building the app, mark-section and mark-success must be executable for the app to build correctly - these two scripts are executable in this repo but it can be easy to miss if the executable bit is lost as it's a metadata change
+- Designed to be used as part of Helios workflow for processing Solid Cancer data for GRCh37 so all defaults are based on that.
+- This app uses a buffer_size of 500 variants and parallelised using 4 cores. This was chosen with the solid cancer vcfs in mind and may need to be tweaked or changed for bigger vcfs.
+  

--- a/Readme.md
+++ b/Readme.md
@@ -42,7 +42,7 @@ Annotate against specified refseq transcripts with
   - Cosmic NonCoding Variants VCF (v94)
       - CosmicNonCodingVariants_v94_grch37.normal.vcf.gz
       - CosmicNonCodingVariants_v94_grch37.normal.vcf.gz.tbi
-  - ClinVar VCF (20211002)
+  - ClinVar VCF (2021113)
       - clinvar_20211113_withChr.vcf.gz
       - clinvar_20211113_withChr.vcf.gz.tbi
   - CADD (v1.6)

--- a/Readme.md
+++ b/Readme.md
@@ -5,7 +5,7 @@
 Annotates a vcf using [Variant Effect Predictor](https://github.com/Ensembl/ensembl-vep). Default docker image used v104.3.
 
 ## What are typical use cases for this app?
-This app was designed to annotate vcfs with specified fields. 
+This app was designed to annotate vcfs with specified fields.
 
 Annotate against specified refseq transcripts with
 - gene symbol
@@ -22,7 +22,6 @@ Annotate against specified refseq transcripts with
 - ClinVar - Clinical Indication
 - ClinVar - Clinical Significance
 - Transcript Feature
-   
 
 ## What data are required for this app to run?
 - An input vcf to annotate
@@ -50,8 +49,7 @@ Annotate against specified refseq transcripts with
       - gnomad.genomes.r2.0.1.sites.noVEP.vcf.gz.tbi
       - cadd_whole_genome_SNVs_GRCh37.tsv.gz
       - cadd_whole_genome_SNVs_GRCh37.tsv.gz.tbi
-  
-  
+
 > All the annotation sources above are specific for GRCh37 and are set us default for the app - this app can run with the equivalent annotation sources for GRCh38.
 
 __This app uses the follow tools which are app assets:__
@@ -63,4 +61,4 @@ __This app uses the follow tools which are app assets:__
 ## Limitations
 - Designed to be used as part of Helios workflow for processing Solid Cancer data for GRCh37 so all defaults are based on that.
 - This app uses a buffer_size of 500 variants and parallelised using 4 cores. This was chosen with the solid cancer vcfs in mind and may need to be tweaked or changed for bigger vcfs.
-  
+

--- a/dxapp.json
+++ b/dxapp.json
@@ -14,7 +14,7 @@
       "label": "vcf file",
       "help": "vcf",
       "class": "file",
-      "patterns": ["*.vcf", "*.vcf.gz"]],
+      "patterns": ["*.vcf", "*.vcf.gz"],
       "optional": false
     },
     {
@@ -91,7 +91,7 @@
       "help": "Reference file annotation sources for VEP and index (ClinVar,CADD, COSMIC, gnomad)",
       "class": "array:file",
       "optional": false,
-      "default": [   
+      "default": [
         {
           "$dnanexus_link": "file-G5KjGZ84YV3xFfv221vJQjQZ"
         },
@@ -128,8 +128,7 @@
         {
           "$dnanexus_link": "file-G6P4QVj433Gk5FbKB11JPG6K"
         }
-        
-      ],  
+      ],
       "suggestions": [
         {
           "name": "001_Reference",
@@ -137,11 +136,11 @@
           "path": "/annotation/b37/"
         }
       ]
-    }    
+    }
   ],
   "outputSpec": [
     {
-      "name": "annotated_filtered_vcf",
+      "name": "annotated_vcf",
       "label": "Filtered and annotated VCF",
       "help": "VCF that has been filtered and annotated using bcftools and VEP",
       "class": "file",

--- a/dxapp.json
+++ b/dxapp.json
@@ -25,7 +25,7 @@
       "patterns": ["*.tar.gz"],
       "optional": false,
       "default": {
-        "$dnanexus_link": "file-G6BYQP8433Gjf2j8KQ0fkvZJ"
+        "$dnanexus_link": "project-Fkb6Gkj433GVVvj73J7x8KbV:file-G6BYQP8433Gjf2j8KQ0fkvZJ"
       },
       "suggestions": [
         {
@@ -43,10 +43,10 @@
       "optional": false,
       "default": [
         {
-          "$dnanexus_link": "file-G6BYQGQ433Gg0KfZF5xPfv1X"
+          "$dnanexus_link": "project-Fkb6Gkj433GVVvj73J7x8KbV:file-G6BYQGQ433Gg0KfZF5xPfv1X"
         },
         {
-          "$dnanexus_link": "file-G6BYQF0433Gb7jGP4qbQx0G6"
+          "$dnanexus_link": "project-Fkb6Gkj433GVVvj73J7x8KbV:file-G6BYQF0433Gb7jGP4qbQx0G6"
         }
       ],
       "suggestions": [
@@ -65,16 +65,16 @@
       "optional": false,
       "default": [
         {
-          "$dnanexus_link": "file-G6BYyyj4YV3pYBkgFVGP2K4P"
+          "$dnanexus_link": "project-Fkb6Gkj433GVVvj73J7x8KbV:file-G6BYyyj4YV3pYBkgFVGP2K4P"
         },
         {
-          "$dnanexus_link": "file-G6P32kj4YV3y58KyP4k4qG2p"
+          "$dnanexus_link": "project-Fkb6Gkj433GVVvj73J7x8KbV:file-G6P32kj4YV3y58KyP4k4qG2p"
         },
         {
-          "$dnanexus_link": "file-G6BYz104YV3X5qp463K5b5vp"
+          "$dnanexus_link": "project-Fkb6Gkj433GVVvj73J7x8KbV:file-G6BYz104YV3X5qp463K5b5vp"
         },
         {
-          "$dnanexus_link": "file-G6KzXQj4YV3YX9116j4xzFyb"
+          "$dnanexus_link": "project-Fkb6Gkj433GVVvj73J7x8KbV:file-G6KzXQj4YV3YX9116j4xzFyb"
         }
       ],
       "suggestions": [
@@ -93,40 +93,40 @@
       "optional": false,
       "default": [
         {
-          "$dnanexus_link": "file-G5KjGZ84YV3xFfv221vJQjQZ"
+          "$dnanexus_link": "project-Fkb6Gkj433GVVvj73J7x8KbV:file-G5KjGZ84YV3xFfv221vJQjQZ"
         },
         {
-          "$dnanexus_link": "file-G5KjKf84YV3y39z97vbXJ60b"
+          "$dnanexus_link": "project-Fkb6Gkj433GVVvj73J7x8KbV:file-G5KjKf84YV3y39z97vbXJ60b"
         },
         {
-          "$dnanexus_link": "file-G6BYB5Q433GvQGgF58976p7J"
+          "$dnanexus_link": "project-Fkb6Gkj433GVVvj73J7x8KbV:file-G6BYB5Q433GvQGgF58976p7J"
         },
         {
-          "$dnanexus_link": "file-G6BYB8j433GyJ3f13z8GB4ZV"
+          "$dnanexus_link": "project-Fkb6Gkj433GVVvj73J7x8KbV:file-G6BYB8j433GyJ3f13z8GB4ZV"
         },
         {
-          "$dnanexus_link": "file-G6BY8X0433GbVBG06pFPvjp7"
+          "$dnanexus_link": "project-Fkb6Gkj433GVVvj73J7x8KbV:file-G6BY8X0433GbVBG06pFPvjp7"
         },
         {
-          "$dnanexus_link": "file-G6BY8Pj433GjPF7j6kK5QZ75"
+          "$dnanexus_link": "project-Fkb6Gkj433GVVvj73J7x8KbV:file-G6BY8Pj433GjPF7j6kK5QZ75"
         },
         {
-          "$dnanexus_link": "file-G6BZ9Pj433GbJPBq21XB939z"
+          "$dnanexus_link": "project-Fkb6Gkj433GVVvj73J7x8KbV:file-G6BZ9Pj433GbJPBq21XB939z"
         },
         {
-          "$dnanexus_link": "file-G6BZ9JQ433GgPPj2Jy5jpvkJ"
+          "$dnanexus_link": "project-Fkb6Gkj433GVVvj73J7x8KbV:file-G6BZ9JQ433GgPPj2Jy5jpvkJ"
         },
         {
-          "$dnanexus_link": "file-G6P4Q50433GQGqgg17ggGX27"
+          "$dnanexus_link": "project-Fkb6Gkj433GVVvj73J7x8KbV:file-G6P4Q50433GQGqgg17ggGX27"
         },
         {
-          "$dnanexus_link": "file-G6P4QK8433GppBFv57QBQB2J"
+          "$dnanexus_link": "project-Fkb6Gkj433GVVvj73J7x8KbV:file-G6P4QK8433GppBFv57QBQB2J"
         },
         {
-          "$dnanexus_link": "file-G6KV6Pj433GkBBF398p6XQXv"
+          "$dnanexus_link": "project-Fkb6Gkj433GVVvj73J7x8KbV:file-G6KV6Pj433GkBBF398p6XQXv"
         },
         {
-          "$dnanexus_link": "file-G6P4QVj433Gk5FbKB11JPG6K"
+          "$dnanexus_link": "project-Fkb6Gkj433GVVvj73J7x8KbV:file-G6P4QVj433Gk5FbKB11JPG6K"
         }
       ],
       "suggestions": [

--- a/dxapp.json
+++ b/dxapp.json
@@ -65,7 +65,7 @@
       "optional": false,
       "default": [
         {
-          "$dnanexus_link": "file-G6BYyyj4YV3pYBkgFVGP2K4P"
+          "$dnanexus_link": ""
         },
         {
           "$dnanexus_link": "file-G6P32kj4YV3y58KyP4k4qG2p"
@@ -91,7 +91,45 @@
       "help": "Reference file annotation sources for VEP and index (ClinVar,CADD, COSMIC, gnomad)",
       "class": "array:file",
       "optional": false,
-      "default": [      
+      "default": [   
+        {
+          "$dnanexus_link": "file-G5KjGZ84YV3xFfv221vJQjQZ"
+        },
+        {
+          "$dnanexus_link": "file-G5KjKf84YV3y39z97vbXJ60b"
+        },
+        {
+          "$dnanexus_link": "file-G6BYB5Q433GvQGgF58976p7J"
+        },
+        {
+          "$dnanexus_link": "file-G6BYB8j433GyJ3f13z8GB4ZV"
+        },
+        {
+          "$dnanexus_link": "file-G6BY8X0433GbVBG06pFPvjp7"
+        },
+        {
+          "$dnanexus_link": "file-G6BY8Pj433GjPF7j6kK5QZ75"
+        },
+        {
+          "$dnanexus_link": "file-G6BZ9Pj433GbJPBq21XB939z"
+        },
+        {
+          "$dnanexus_link": "file-G6BZ9JQ433GgPPj2Jy5jpvkJ"
+        },
+        {
+          "$dnanexus_link": "file-G6P4Q50433GQGqgg17ggGX27"
+        },
+        {
+          "$dnanexus_link": "file-G6P4QK8433GppBFv57QBQB2J"
+        },
+        {
+          "$dnanexus_link": "file-G6KV6Pj433GkBBF398p6XQXv"
+        },
+        {
+          "$dnanexus_link": "file-G6P4QVj433Gk5FbKB11JPG6K"
+        }
+        
+      ],  
       "suggestions": [
         {
           "name": "001_Reference",

--- a/dxapp.json
+++ b/dxapp.json
@@ -14,7 +14,7 @@
       "label": "vcf file",
       "help": "vcf",
       "class": "file",
-      "patterns": ["*.vcf"],
+      "patterns": ["*.vcf", "*.vcf.gz"]],
       "optional": false
     },
     {
@@ -65,7 +65,16 @@
       "optional": false,
       "default": [
         {
-          "$dnanexus_link": "file-G6BZQQQ433Gqv3GFKy5yKVJV"
+          "$dnanexus_link": "file-G6BYyyj4YV3pYBkgFVGP2K4P"
+        },
+        {
+          "$dnanexus_link": "file-G6P32kj4YV3y58KyP4k4qG2p"
+        },
+        {
+          "$dnanexus_link": "file-G6BYz104YV3X5qp463K5b5vp"
+        },
+        {
+          "$dnanexus_link": "file-G6KzXQj4YV3YX9116j4xzFyb"
         }
       ],
       "suggestions": [
@@ -83,43 +92,6 @@
       "class": "array:file",
       "optional": false,
       "default": [      
-        {
-          "$dnanexus_link": "file-G6BZ9Pj433GbJPBq21XB939z"
-        },
-        {
-          "$dnanexus_link": "file-G6BZ9JQ433GgPPj2Jy5jpvkJ"
-        },
-        {
-          "$dnanexus_link": "file-G5KjGZ84YV3xFfv221vJQjQZ"
-        },
-        {
-          "$dnanexus_link": "file-G5KjKf84YV3y39z97vbXJ60b"
-        },
-        {
-          "$dnanexus_link": "file-G6BYB5Q433GvQGgF58976p7J"
-        },
-        {
-          "$dnanexus_link": "file-G6BYB8j433GyJ3f13z8GB4ZV"
-        },
-        {
-          "$dnanexus_link": "file-G6BY8X0433GbVBG06pFPvjp7"
-        },
-        {
-          "$dnanexus_link": "file-G6BY8Pj433GjPF7j6kK5QZ75"
-        },
-        {
-          "$dnanexus_link": "file-G6P4Q50433GQGqgg17ggGX27"
-        },
-        {
-          "$dnanexus_link": "file-G6KV6Pj433GkBBF398p6XQXv"
-        },
-        {
-          "$dnanexus_link": "file-G6P4QK8433GppBFv57QBQB2J"
-        },
-        {
-          "$dnanexus_link": "file-G6P4QVj433Gk5FbKB11JPG6K"
-        }
-      ],
       "suggestions": [
         {
           "name": "001_Reference",

--- a/dxapp.json
+++ b/dxapp.json
@@ -25,7 +25,10 @@
       "patterns": ["*.tar.gz"],
       "optional": false,
       "default": {
-        "$dnanexus_link": "project-Fkb6Gkj433GVVvj73J7x8KbV:file-G6BYQP8433Gjf2j8KQ0fkvZJ"
+        "$dnanexus_link": {
+          "project": "project-Fkb6Gkj433GVVvj73J7x8KbV",
+          "id": "file-G6BYQP8433Gjf2j8KQ0fkvZJ"
+        }
       },
       "suggestions": [
         {
@@ -43,10 +46,16 @@
       "optional": false,
       "default": [
         {
-          "$dnanexus_link": "project-Fkb6Gkj433GVVvj73J7x8KbV:file-G6BYQGQ433Gg0KfZF5xPfv1X"
+          "$dnanexus_link": {
+            "project": "project-Fkb6Gkj433GVVvj73J7x8KbV",
+            "id": "file-G6BYQGQ433Gg0KfZF5xPfv1X"
+          }
         },
         {
-          "$dnanexus_link": "project-Fkb6Gkj433GVVvj73J7x8KbV:file-G6BYQF0433Gb7jGP4qbQx0G6"
+          "$dnanexus_link": {
+            "project": "project-Fkb6Gkj433GVVvj73J7x8KbV",
+            "id": "file-G6BYQF0433Gb7jGP4qbQx0G6"
+          }
         }
       ],
       "suggestions": [
@@ -65,16 +74,28 @@
       "optional": false,
       "default": [
         {
-          "$dnanexus_link": "project-Fkb6Gkj433GVVvj73J7x8KbV:file-G6BYyyj4YV3pYBkgFVGP2K4P"
+          "$dnanexus_link": {
+            "project": "project-Fkb6Gkj433GVVvj73J7x8KbV",
+            "id": "file-G6BYyyj4YV3pYBkgFVGP2K4P"
+          }
         },
         {
-          "$dnanexus_link": "project-Fkb6Gkj433GVVvj73J7x8KbV:file-G6P32kj4YV3y58KyP4k4qG2p"
+          "$dnanexus_link": {
+            "project": "project-Fkb6Gkj433GVVvj73J7x8KbV",
+            "id": "file-G6P32kj4YV3y58KyP4k4qG2p"
+          }
         },
         {
-          "$dnanexus_link": "project-Fkb6Gkj433GVVvj73J7x8KbV:file-G6BYz104YV3X5qp463K5b5vp"
+          "$dnanexus_link": {
+            "project": "project-Fkb6Gkj433GVVvj73J7x8KbV",
+            "id": "file-G6BYz104YV3X5qp463K5b5vp"
+          }
         },
         {
-          "$dnanexus_link": "project-Fkb6Gkj433GVVvj73J7x8KbV:file-G6KzXQj4YV3YX9116j4xzFyb"
+          "$dnanexus_link": {
+            "project": "project-Fkb6Gkj433GVVvj73J7x8KbV",
+            "id": "file-G6QGkZ84YV3QZfg551QqkxQX"
+          }
         }
       ],
       "suggestions": [
@@ -93,40 +114,76 @@
       "optional": false,
       "default": [
         {
-          "$dnanexus_link": "project-Fkb6Gkj433GVVvj73J7x8KbV:file-G5KjGZ84YV3xFfv221vJQjQZ"
+          "$dnanexus_link": {
+            "project": "project-Fkb6Gkj433GVVvj73J7x8KbV",
+            "id": "file-G5KjGZ84YV3xFfv221vJQjQZ"
+          }
         },
         {
-          "$dnanexus_link": "project-Fkb6Gkj433GVVvj73J7x8KbV:file-G5KjKf84YV3y39z97vbXJ60b"
+          "$dnanexus_link": {
+            "project": "project-Fkb6Gkj433GVVvj73J7x8KbV",
+            "id": "file-G5KjKf84YV3y39z97vbXJ60b"
+          }
         },
         {
-          "$dnanexus_link": "project-Fkb6Gkj433GVVvj73J7x8KbV:file-G6BYB5Q433GvQGgF58976p7J"
+          "$dnanexus_link": {
+            "project": "project-Fkb6Gkj433GVVvj73J7x8KbV",
+            "id": "file-G6BYB5Q433GvQGgF58976p7J"
+          }
         },
         {
-          "$dnanexus_link": "project-Fkb6Gkj433GVVvj73J7x8KbV:file-G6BYB8j433GyJ3f13z8GB4ZV"
+          "$dnanexus_link": {
+            "project": "project-Fkb6Gkj433GVVvj73J7x8KbV",
+            "id": "file-G6BYB8j433GyJ3f13z8GB4ZV"
+          }
         },
         {
-          "$dnanexus_link": "project-Fkb6Gkj433GVVvj73J7x8KbV:file-G6BY8X0433GbVBG06pFPvjp7"
+          "$dnanexus_link": {
+            "project": "project-Fkb6Gkj433GVVvj73J7x8KbV",
+            "id": "file-G6BY8X0433GbVBG06pFPvjp7"
+          }
         },
         {
-          "$dnanexus_link": "project-Fkb6Gkj433GVVvj73J7x8KbV:file-G6BY8Pj433GjPF7j6kK5QZ75"
+          "$dnanexus_link": {
+            "project": "project-Fkb6Gkj433GVVvj73J7x8KbV",
+            "id": "file-G6BY8Pj433GjPF7j6kK5QZ75"
+          }
         },
         {
-          "$dnanexus_link": "project-Fkb6Gkj433GVVvj73J7x8KbV:file-G6BZ9Pj433GbJPBq21XB939z"
+          "$dnanexus_link": {
+            "project": "project-Fkb6Gkj433GVVvj73J7x8KbV",
+            "id": "file-G6BZ9Pj433GbJPBq21XB939z"
+          }
         },
         {
-          "$dnanexus_link": "project-Fkb6Gkj433GVVvj73J7x8KbV:file-G6BZ9JQ433GgPPj2Jy5jpvkJ"
+          "$dnanexus_link": {
+            "project": "project-Fkb6Gkj433GVVvj73J7x8KbV",
+            "id": "file-G6BZ9JQ433GgPPj2Jy5jpvkJ"
+          }
         },
         {
-          "$dnanexus_link": "project-Fkb6Gkj433GVVvj73J7x8KbV:file-G6P4Q50433GQGqgg17ggGX27"
+          "$dnanexus_link": {
+            "project": "project-Fkb6Gkj433GVVvj73J7x8KbV",
+            "id": "file-G6P4Q50433GQGqgg17ggGX27"
+          }
         },
         {
-          "$dnanexus_link": "project-Fkb6Gkj433GVVvj73J7x8KbV:file-G6P4QK8433GppBFv57QBQB2J"
+          "$dnanexus_link": {
+            "project": "project-Fkb6Gkj433GVVvj73J7x8KbV",
+            "id": "file-G6P4QK8433GppBFv57QBQB2J"
+          }
         },
         {
-          "$dnanexus_link": "project-Fkb6Gkj433GVVvj73J7x8KbV:file-G6KV6Pj433GkBBF398p6XQXv"
+          "$dnanexus_link": {
+            "project": "project-Fkb6Gkj433GVVvj73J7x8KbV",
+            "id": "file-G6KV6Pj433GkBBF398p6XQXv"
+          }
         },
         {
-          "$dnanexus_link": "project-Fkb6Gkj433GVVvj73J7x8KbV:file-G6P4QVj433Gk5FbKB11JPG6K"
+          "$dnanexus_link": {
+            "project": "project-Fkb6Gkj433GVVvj73J7x8KbV",
+            "id": "file-G6P4QVj433Gk5FbKB11JPG6K"
+          }
         }
       ],
       "suggestions": [

--- a/dxapp.json
+++ b/dxapp.json
@@ -136,6 +136,14 @@
           "path": "/annotation/b37/"
         }
       ]
+    },
+    {
+      "name": "buffer_size",
+      "label": "Number of variants to annotate",
+      "help": "To make annoating  more efficient, the number of variants to annotate can chosen. Default is 500 but can be tweaked for bigger files.",
+      "class": "int",
+      "optional": true,
+      "default": 500
     }
   ],
   "outputSpec": [

--- a/dxapp.json
+++ b/dxapp.json
@@ -11,10 +11,10 @@
   "inputSpec": [
     {
       "name": "vcf",
-      "label": "gzipped vcf",
+      "label": "vcf file",
       "help": "vcf",
       "class": "file",
-      "patterns": ["*.vcf.gz"],
+      "patterns": ["*.vcf"],
       "optional": false
     },
     {
@@ -106,6 +106,18 @@
         },
         {
           "$dnanexus_link": "file-G6BY8Pj433GjPF7j6kK5QZ75"
+        },
+        {
+          "$dnanexus_link": "file-G6P4Q50433GQGqgg17ggGX27"
+        },
+        {
+          "$dnanexus_link": "file-G6KV6Pj433GkBBF398p6XQXv"
+        },
+        {
+          "$dnanexus_link": "file-G6P4QK8433GppBFv57QBQB2J"
+        },
+        {
+          "$dnanexus_link": "file-G6P4QVj433Gk5FbKB11JPG6K"
         }
       ],
       "suggestions": [

--- a/dxapp.json
+++ b/dxapp.json
@@ -65,7 +65,7 @@
       "optional": false,
       "default": [
         {
-          "$dnanexus_link": ""
+          "$dnanexus_link": "file-G6BYyyj4YV3pYBkgFVGP2K4P"
         },
         {
           "$dnanexus_link": "file-G6P32kj4YV3y58KyP4k4qG2p"

--- a/dxapp.json
+++ b/dxapp.json
@@ -18,77 +18,112 @@
       "optional": false
     },
     {
-      "name": "bed",
-      "label": "bed file used to define regions of interest",
-      "help": "The bed file will be used to remove variants outside the regions of interest",
+      "name": "vep_docker",
+      "label": "VEP docker image",
+      "help": "compressed docker image of VEP",
       "class": "file",
-      "patterns": ["coding_unrestricted*.bed"],
-      "default": {"$dnanexus_link": "file-FybyxV841zgB8v1y3fFbFB0G"},
+      "patterns": ["*.tar.gz"],
+      "optional": false,
+      "default": {
+        "$dnanexus_link": "file-G6BYQP8433Gjf2j8KQ0fkvZJ"
+      },
       "suggestions": [
         {
           "name": "001_Reference",
           "project": "project-Fkb6Gkj433GVVvj73J7x8KbV",
-          "path": "/bed_files/b38/kits/myeloid"
+          "path": "/assets/vep/vep_docker_v104.3/"
         }
-      ],
-      "optional": false
+      ]
     },
     {
-      "name": "mutect2_fasta",
-      "label": "FASTA for bcftools to split multiallelics",
-      "help": "Should be equivalent FASTA as used by mutect2",
-      "class": "file",
-      "patterns": ["GRCh38.no_alt_analysis_set_chr_mask21.fa.gz"],
-      "default": {"$dnanexus_link": "file-Fy4gjFj41zgGjKJ85FYYPX4q"},
+      "name": "vep_plugins",
+      "label": "plugin files for VEP",
+      "help": "Associated plugin files for VEP",
+      "class": "array:file",
+      "optional": false,
+      "default": [
+        {
+          "$dnanexus_link": "file-G6BYQGQ433Gg0KfZF5xPfv1X"
+        },
+        {
+          "$dnanexus_link": "file-G6BYQF0433Gb7jGP4qbQx0G6"
+        }
+      ],
       "suggestions": [
         {
           "name": "001_Reference",
           "project": "project-Fkb6Gkj433GVVvj73J7x8KbV",
-          "path": "/genomes/b38"
+          "path": "/assets/vep/vep_docker_v104.3/"
         }
-      ],
-      "optional": false
+      ]
     },
     {
-      "name": "mutect2_fai",
-      "label": "mutect2 fai index",
-      "help": "Should be equivalent fai index as used by mutect2",
-      "class": "file",
-      "patterns": ["GRCh38.no_alt_analysis_set_chr_mask21.fa.fai"],
-      "default": {"$dnanexus_link": "file-FyFGvzQ41zgBq7xf4Gy9Q28g"},
+      "name": "vep_refs",
+      "label": "reference sources for VEP",
+      "help": "Reference file annotation sources required for VEP",
+      "class": "array:file",
+      "optional": false,
+      "default": [
+        {
+          "$dnanexus_link": "file-G6BZQQQ433Gqv3GFKy5yKVJV"
+        }
+      ],
       "suggestions": [
         {
           "name": "001_Reference",
           "project": "project-Fkb6Gkj433GVVvj73J7x8KbV",
-          "path": "/genomes/b38"
+          "path": "/annotation/b37/vep/"
         }
-      ],
-      "optional": false
+      ]
     },
     {
-      "name": "vep_tarball",
-      "label": "vep docker and annotation sources",
-      "help": "tarball containing VEP docker image, plugins and annotation sources",
-      "class": "file",
-      "patterns": ["vep*.tar"],
-      "default": {"$dnanexus_link": "file-G2K4XZQ433GXjVfF58jJ0F05"},
+      "name": "vep_annotation",
+      "label": "annotation sources for VEP",
+      "help": "Reference file annotation sources for VEP and index (ClinVar,CADD, COSMIC, gnomad)",
+      "class": "array:file",
+      "optional": false,
+      "default": [      
+        {
+          "$dnanexus_link": "file-G6BZ9Pj433GbJPBq21XB939z"
+        },
+        {
+          "$dnanexus_link": "file-G6BZ9JQ433GgPPj2Jy5jpvkJ"
+        },
+        {
+          "$dnanexus_link": "file-G5KjGZ84YV3xFfv221vJQjQZ"
+        },
+        {
+          "$dnanexus_link": "file-G5KjKf84YV3y39z97vbXJ60b"
+        },
+        {
+          "$dnanexus_link": "file-G6BYB5Q433GvQGgF58976p7J"
+        },
+        {
+          "$dnanexus_link": "file-G6BYB8j433GyJ3f13z8GB4ZV"
+        },
+        {
+          "$dnanexus_link": "file-G6BY8X0433GbVBG06pFPvjp7"
+        },
+        {
+          "$dnanexus_link": "file-G6BY8Pj433GjPF7j6kK5QZ75"
+        }
+      ],
       "suggestions": [
         {
           "name": "001_Reference",
           "project": "project-Fkb6Gkj433GVVvj73J7x8KbV",
-          "path": "/assets/vep/vep_v103.1.3"
+          "path": "/annotation/b37/"
         }
-      ],
-      "optional": false
-    }
+      ]
+    }    
   ],
   "outputSpec": [
     {
-      "name": "allgenes_filtered_vcf",
-      "label": "Filtered and annotated VCF for all panel genes",
-      "help": "VCF that has been filtered and annotated using bedtools, bcftools and VEP",
+      "name": "annotated_filtered_vcf",
+      "label": "Filtered and annotated VCF",
+      "help": "VCF that has been filtered and annotated using bcftools and VEP",
       "class": "file",
-      "patterns": ["*allgenesvep.vcf"]
+      "patterns": ["*annotated.vcf"]
     }
   ],
   "runSpec": {
@@ -112,11 +147,15 @@
       {
         "name": "htslib",
         "project": "project-Fkb6Gkj433GVVvj73J7x8KbV",
-        "folder": "/app_assets/htslib/htslib_v1.12.0",
-        "version": "1.12.0"
+        "folder": "/app_assets/htslib/htslib_v1.14.0",
+        "version": "1.14.0"
       }
     ]
   },
+  "developers":[
+    "user-toutoua",
+    "org-emee_1"
+  ],
   "authorizedUsers": [
     "org-emee_1"
   ],

--- a/src/code.sh
+++ b/src/code.sh
@@ -47,7 +47,7 @@ function annotate_vep_vcf {
 	--custom /opt/vep/.vep/"${cosmic_non_coding}",COSMIC,vcf,exact,0,ID \
   	--custom /opt/vep/.vep/"${gnomad_genome_vcf}",gnomADg,vcf,exact,0,AF,AF_AFR,AF_AMR,AF_ASJ,AF_EAS,AF_FIN,AF_NFE,AF_OTH \
 	--plugin CADD,/opt/vep/.vep/"${cadd_snv}",/opt/vep/.vep/"${cadd_indel}" \
-	--fields "$filter_fields" \
+	--fields "$filter_fields" --buffer_size 500 --fork 4 \
 	--no_stats
 }
 

--- a/src/code.sh
+++ b/src/code.sh
@@ -52,7 +52,7 @@ function annotate_vep_vcf {
 	--custom /opt/vep/.vep/"${cosmic_non_coding}",COSMIC,vcf,exact,0,ID \
 	--custom /opt/vep/.vep/"${gnomad_genome_vcf}",gnomADg,vcf,exact,0,AF,AF_AFR,AF_AMR,AF_ASJ,AF_EAS,AF_FIN,AF_NFE,AF_OTH \
 	--plugin CADD,/opt/vep/.vep/"${cadd_snv}",/opt/vep/.vep/"${cadd_indel}" \
-	--fields "$filter_fields" --buffer_size  $buffer_size --fork "$forks" \
+	--fields "$filter_fields" --buffer_size "$buffer_size" --fork "$forks" \
 	--no_stats
 }
 
@@ -81,7 +81,13 @@ main() {
 
 	# place fasta and indexes for VEP in the annotation folder
 	chmod a+rwx /home/dnanexus/in/vep_refs/*fa.gz*
-	mv /home/dnanexus/in/vep_refs/*fa.gz* ~/homo_sapiens_refseq/104_GRCh37/
+
+	# Find the annotation cache folder dynamically to allow different versions of VEP and genome to be used
+	# This will only work with refseq annotation caches currently as this is passed in the VEP command
+	# We can consider changing this if non-refseq files are required but it needs the --refseq flag to become optional
+	cache_path=$(find homo_sapiens_refseq -mindepth 1 -maxdepth 1 -type d -name "*_GRCh3*" )
+	echo "$cache_path"
+	mv /home/dnanexus/in/vep_refs/*fa.gz* ~/"${cache_path}"
 
 	# place plugins into plugins folder
 	mkdir ~/Plugins

--- a/src/code.sh
+++ b/src/code.sh
@@ -32,8 +32,8 @@ function annotate_vep_vcf {
 	cadd_snv=$(find ./ -name "*SNVs.tsv.gz")
 	cadd_indel=$(find ./ -name "*indel.tsv.gz")
 
-  # find gnomad files, remove leading ./
-  gnomad_genome_vcf=$(find ./ -name "gnomad.genomes.*.vcf.gz" | sed s'/.\///')
+	# find gnomad files, remove leading ./
+  	gnomad_genome_vcf=$(find ./ -name "gnomad.genomes.*.vcf.gz" | sed s'/.\///')
 
 	time docker run -v /home/dnanexus:/opt/vep/.vep \
 	ensemblorg/ensembl-vep:release_104.3 \
@@ -64,7 +64,6 @@ main() {
 	# move annotation sources to home
 	mv ~/in/vep_annotation/* /home/dnanexus/
 
-
 	mark-section "annotating"
 	
 	# vep needs permissions to write to /home/dnanexus
@@ -84,9 +83,25 @@ main() {
 	# load vep docker
 	docker load -i "$vep_docker_path"
 
+	#annotate
+	output_vcf="${vcf_prefix}_annotated.vcf"
+	print ($output_vcf)
+	annotate_vep_vcf "$vcf" "$output_vcf"
+
 	mark-section "uploading output"
 
   # upload output files
+
+	# Upload output vcf
+    annotated_filtered_vcf=$(dx upload $output_vcf --brief)
+
+    # The following line(s) use the utility dx-jobutil-add-output to format and
+    # add output variables to your job's output as appropriate for the output
+    # class.  Run "dx-jobutil-add-output -h" for more information on what it
+    # does.
+
+    dx-jobutil-add-output annotated_filtered_vcf "$annotated_filtered_vcf" --class=file
+	
 	
 	mark-success
 }

--- a/src/code.sh
+++ b/src/code.sh
@@ -45,7 +45,7 @@ function annotate_vep_vcf {
 	--custom /opt/vep/.vep/"${clinvar_vcf}",ClinVar,vcf,exact,0,CLNSIG,CLNREVSTAT,CLNDN \
 	--custom /opt/vep/.vep/"${cosmic_coding}",COSMIC,vcf,exact,0,ID \
 	--custom /opt/vep/.vep/"${cosmic_non_coding}",COSMIC,vcf,exact,0,ID \
-  	--custom /opt/vep/.vep/"${gnomad_genome_vcf}",gnomADg,vcf,exact,0,AF,AF_AFR,AF_AMR,AF_ASJ,AF_EAS,AF_FIN,AF_NFE,AF_OTH \
+	--custom /opt/vep/.vep/"${gnomad_genome_vcf}",gnomADg,vcf,exact,0,AF,AF_AFR,AF_AMR,AF_ASJ,AF_EAS,AF_FIN,AF_NFE,AF_OTH \
 	--plugin CADD,/opt/vep/.vep/"${cadd_snv}",/opt/vep/.vep/"${cadd_indel}" \
 	--fields "$filter_fields" --buffer_size 500 --fork 4 \
 	--no_stats
@@ -94,8 +94,8 @@ main() {
 	mark-section "uploading output"
 
 	# Upload output vcf
-    annotated_vcf=$(dx upload $output_vcf --brief)
-    dx-jobutil-add-output annotated_filtered_vcf "$annotated_vcf" --class=file
+	annotated_vcf=$(dx upload $output_vcf --brief)
+	dx-jobutil-add-output annotated_filtered_vcf "$annotated_vcf" --class=file
 
 	mark-success
 }

--- a/src/code.sh
+++ b/src/code.sh
@@ -32,6 +32,11 @@ function annotate_vep_vcf {
 	# which is missing in the standard gnomad annotation for GRCh37
   	gnomad_genome_vcf=$(find ./ -name "gnomad.genomes.*.vcf.gz" | sed s'/.\///')
 
+	# Get number of cores/threads to use in --fork option
+	forks=$(grep -c ^processor /proc/cpuinfo)
+	echo "Number of forks: $forks"
+	echo "Buffer size used: $buffer_size"
+
 	# --exclude_null_allelels is used with --check-existing to prevent multiple COSMIC id's
 	# being added to the same variant.
 	# the buffer size is chosen based on the average size of the input VCF
@@ -47,7 +52,7 @@ function annotate_vep_vcf {
 	--custom /opt/vep/.vep/"${cosmic_non_coding}",COSMIC,vcf,exact,0,ID \
 	--custom /opt/vep/.vep/"${gnomad_genome_vcf}",gnomADg,vcf,exact,0,AF,AF_AFR,AF_AMR,AF_ASJ,AF_EAS,AF_FIN,AF_NFE,AF_OTH \
 	--plugin CADD,/opt/vep/.vep/"${cadd_snv}",/opt/vep/.vep/"${cadd_indel}" \
-	--fields "$filter_fields" --buffer_size 500 --fork 4 \
+	--fields "$filter_fields" --buffer_size  $buffer_size --fork "$forks" \
 	--no_stats
 }
 

--- a/src/code.sh
+++ b/src/code.sh
@@ -101,14 +101,14 @@ main() {
   # upload output files
 
 	# Upload output vcf
-    annotated_filtered_vcf=$(dx upload $output_vcf --brief)
+    annotated_vcf=$(dx upload $output_vcf --brief)
 
     # The following line(s) use the utility dx-jobutil-add-output to format and
     # add output variables to your job's output as appropriate for the output
     # class.  Run "dx-jobutil-add-output -h" for more information on what it
     # does.
 
-    dx-jobutil-add-output annotated_filtered_vcf "$annotated_filtered_vcf" --class=file
+    dx-jobutil-add-output annotated_filtered_vcf "$annotated_vcf" --class=file
 	
 	
 	mark-success

--- a/src/code.sh
+++ b/src/code.sh
@@ -19,7 +19,8 @@ function annotate_vep_vcf {
 	
 	# fields to filter on
 	# hard coded in function for now, can be made an input but all are the same
-	filter_fields="SYMBOL,VARIANT_CLASS,Consequence,EXON,HGVSc,HGVSp,gnomAD_AF,gnomADg_AF,CADD_PHRED,Existing_variation,ClinVar,ClinVar_CLNDN,ClinVar_CLNSIG,COSMIC,Feature"
+	filter_fields="SYMBOL,VARIANT_CLASS,Consequence,EXON,HGVSc,HGVSp,gnomAD_AF,gnomADg_AF, \
+	CADD_PHRED,Existing_variation,ClinVar,ClinVar_CLNDN,ClinVar_CLNSIG,COSMIC,Feature"
 
 	# find clinvar vcf, remove leading ./
 	clinvar_vcf=$(find ./ -name "clinvar_*.vcf.gz" | sed s'/.\///')
@@ -29,7 +30,7 @@ function annotate_vep_vcf {
 	cosmic_non_coding=$(find ./ -name "CosmicNonCodingVariants*.vcf.gz" | sed s'/.\///')
 
 	# find CADD files, remove leading ./
-	cadd_snv=$(find ./ -name "*SNVs.tsv.gz")
+	cadd_snv=$(find ./ -name "*SNVs*.tsv.gz")
 	cadd_indel=$(find ./ -name "*indel.tsv.gz")
 
 	# find gnomad files, remove leading ./
@@ -44,7 +45,7 @@ function annotate_vep_vcf {
 	--custom /opt/vep/.vep/"${clinvar_vcf}",ClinVar,vcf,exact,0,CLNSIG,CLNREVSTAT,CLNDN \
 	--custom /opt/vep/.vep/"${cosmic_coding}",COSMIC,vcf,exact,0,ID \
 	--custom /opt/vep/.vep/"${cosmic_non_coding}",COSMIC,vcf,exact,0,ID \
-  --custom /opt/vep/.vep/"${gnomad_genome_vcf}",gnomADg,vcf,exact,0,AF,AF_AFR,AF_AMR,AF_ASJ,AF_EAS,AF_FIN,AF_NFE,AF_OTH \
+  	--custom /opt/vep/.vep/"${gnomad_genome_vcf}",gnomADg,vcf,exact,0,AF,AF_AFR,AF_AMR,AF_ASJ,AF_EAS,AF_FIN,AF_NFE,AF_OTH \
 	--plugin CADD,/opt/vep/.vep/"${cadd_snv}",/opt/vep/.vep/"${cadd_indel}" \
 	--fields "$filter_fields" \
 	--no_stats
@@ -61,8 +62,9 @@ main() {
 	find ~/in/vep_refs -type f -name "*" -print0 | xargs -0 -I {} mv {} ~/in/vep_refs
 	find ~/in/vep_annotation -type f -name "*" -print0 | xargs -0 -I {} mv {} ~/in/vep_annotation
 
-	# move annotation sources to home
+	# move annotation sources and input vcf to home 
 	mv ~/in/vep_annotation/* /home/dnanexus/
+	mv ~/in/vcf/* /home/dnanexus/
 
 	mark-section "annotating"
 	
@@ -73,6 +75,7 @@ main() {
 	time tar xf /home/dnanexus/in/vep_refs/*.tar.gz -C /home/dnanexus
 
 	# place fasta and indexes for VEP in the annotation folder
+	chmod a+rwx /home/dnanexus/in/vep_refs/*fa.gz*
 	mv /home/dnanexus/in/vep_refs/*fa.gz* ~/homo_sapiens_refseq/104_GRCh37/
 
 	# place plugins into plugins folder
@@ -85,8 +88,8 @@ main() {
 
 	#annotate
 	output_vcf="${vcf_prefix}_annotated.vcf"
-	print ($output_vcf)
-	annotate_vep_vcf "$vcf" "$output_vcf"
+	echo $output_vcf
+	annotate_vep_vcf "$vcf_name" "$output_vcf"
 
 	mark-section "uploading output"
 

--- a/src/code.sh
+++ b/src/code.sh
@@ -106,7 +106,7 @@ main() {
 
 	# Upload output vcf
 	annotated_vcf=$(dx upload $output_vcf --brief)
-	dx-jobutil-add-output annotated_filtered_vcf "$annotated_vcf" --class=file
+	dx-jobutil-add-output annotated_vcf "$annotated_vcf" --class=file
 
 	mark-success
 }

--- a/src/code.sh
+++ b/src/code.sh
@@ -1,148 +1,92 @@
 #!/bin/bash
 #
-# Decomposed multiallelic variants
-# Annotates variants using VEP
-#
-# The following line causes bash to exit at any point if there is any error
-# and to output each line as it is executed -- useful for debugging
-# Additionally -v is included here (enables "Print shell input lines as they
-# are read") to overcome issues with how quotes are displayed in the log
-# (sometimes single quotes become no quotes and double quotes become single
-# quotes)
-# See https://www.gnu.org/software/bash/manual/html_node/The-Set-Builtin.html
-set -e -x -v -o pipefail
+# Performs annotation and filtering of given mutect2 VCF to produce multiple annotated VCFs
+# Performs filtering and annotation of given pindel VCF to produce annotated VCF
+# n.b. filtering for pindel is a combination of a bed file of regions, removal of all 1-2bp
+# insetions and filtering by transcript with vep
+# Generates an excel workbook to aid variant interpretation
+# Also generates a workaround for BSVI mis-handling multiallelics
 
-mark-section "downloading inputs"
-dx-download-all-inputs --parallel
+function annotate_vep_vcf {
+	# Function to run VEP for annotation on given VCF file
 
-mark-section "filtering and splitting multiallelics"
-# retain variants that are: # within ROIs (bed file),
-#   have at least one allele >0.03 AF, and have DP >99
-# fix AD and RPA number in header
-# split multiallelics using --keep-sum AD which changes the ref AD to be a sum
-#   of all other AD's rather than being ref AD alone
-# note that --keep-sum AD is a one way conversion in bcftools 1.12.0 and can't
-#   be undone with bcftools norm -m +any
-# bedtools and bcftools are app assets
-splitfile="${vcf_prefix}_split.vcf"
-bedtools intersect -header -a "${vcf_path}" -b "${bed_path}" \
-  | bcftools view -i "FORMAT/AF[*]>0.03" - \
-  | bcftools view -i "DP>99" - \
-  | sed 's/AD,Number=./AD,Number=R/g' \
-  | sed 's/RPA,Number=./RPA,Number=R/g' \
-  | bcftools norm -f "${mutect2_fasta_path}" -m -any --keep-sum AD - \
-  -o ~/"${splitfile}"
+	# Inputs:
+	# $1 -> input vcf 
+	# $2 -> name for output vcf
 
+	input_vcf="$1"
+	output_vcf="$2"
+	
+	# fields to filter on
+	# hard coded in function for now, can be made an input but all are the same
+	filter_fields="SYMBOL,VARIANT_CLASS,Consequence,EXON,HGVSc,HGVSp,gnomAD_AF,gnomADg_AF,CADD_PHRED,Existing_variation,ClinVar,ClinVar_CLNDN,ClinVar_CLNSIG,COSMIC,Feature"
 
-mark-section "annotating and further filtering"
-# vep needs permissions to write to /home/dnanexus
-chmod a+rwx /home/dnanexus
-# extract vep tarball (input) to /home/dnanexus
-tar xf "${vep_tarball_path}" -C /home/dnanexus
-# extract annotation tarball to /home/dnanexus
-tar xf ~/homo_sapiens_refseq_vep_103_GRCh38.tar.gz
-# place fasta and indexes for VEP in the annotation folder
-mv ~/Homo_sapiens.GRCh38.dna.toplevel.fa.gz \
-  ~/homo_sapiens_refseq/103_GRCh38/
-mv ~/Homo_sapiens.GRCh38.dna.toplevel.fa.gz.fai \
-  ~/homo_sapiens_refseq/103_GRCh38/
-mv ~/Homo_sapiens.GRCh38.dna.toplevel.fa.gz.gzi \
-  ~/homo_sapiens_refseq/103_GRCh38/
-# place plugins into plugins folder
-mkdir ~/Plugins
-mv ~/CADD.pm ~/Plugins/
-mv ~/plugin_config.txt ~/Plugins/
-# load vep docker (asset)
-docker load -i ~/vep_v103.1_docker.tar.gz
-# will run vep to annotate against specified transcripts for all, lymphoid
-# and myeloid gene lists
-# run vep for all genes list
-allgenesfile="${vcf_prefix}_allgenes.vcf"
-docker run -v /home/dnanexus:/opt/vep/.vep \
-  ensemblorg/ensembl-vep:release_103.1 \
-  ./vep -i /opt/vep/.vep/"${splitfile}" -o /opt/vep/.vep/"${allgenesfile}" \
-  --vcf --cache --refseq --exclude_predicted --symbol --hgvs --af_gnomad \
-  --check_existing --variant_class --numbers \
-  --custom /opt/vep/.vep/clinvar_withchr_20210501.vcf.gz,ClinVar,vcf,exact,0,CLNSIG,CLNREVSTAT,CLNDN \
-  --custom /opt/vep/.vep/138_merge_sort.vcf.gz,Prev,vcf,exact,0,AC,NS \
-  --plugin CADD,/opt/vep/.vep/whole_genome_SNVs.tsv.gz,/opt/vep/.vep/gnomad.genomes.r3.0.indel.tsv.gz \
-  --fields \
-  "SYMBOL,VARIANT_CLASS,Consequence,EXON,HGVSc,HGVSp,gnomAD_AF,CADD_PHRED,Existing_variation,ClinVar,ClinVar_CLNDN,ClinVar_CLNSIG,Prev_AC,Prev_NS" \
-  --no_stats --transcript_filter \
-  "stable_id match NM_002074 \
-  or stable_id match NM_000760 \
-  or stable_id match NM_005373 \
-  or stable_id match NM_002227 \
-  or stable_id match NM_002524 \
-  or stable_id match NM_022552 \
-  or stable_id match NM_012433 \
-  or stable_id match NM_005896 \
-  or stable_id match NM_002468 \
-  or stable_id match NM_032638 \
-  or stable_id match NM_000222 \
-  or stable_id match NM_001127208 \
-  or stable_id match NM_033632 \
-  or stable_id match NM_002520 \
-  or stable_id match NM_016222 \
-  or stable_id match NM_006060 \
-  or stable_id match NM_181500 \
-  or stable_id match NM_004333 \
-  or stable_id match NM_004456 \
-  or stable_id match NM_170606 \
-  or stable_id match NM_006265 \
-  or stable_id match NM_004972 \
-  or stable_id match NM_016734 \
-  or stable_id match NM_017617 \
-  or stable_id match NM_000314 \
-  or stable_id match NM_005343 \
-  or stable_id match NM_024426 \
-  or stable_id match NM_001165 \
-  or stable_id match NM_000051 \
-  or stable_id match NM_001197104 \
-  or stable_id match NM_005188 \
-  or stable_id match NM_001987 \
-  or stable_id match NM_018638 \
-  or stable_id match NM_033360 \
-  or stable_id match NM_001136023 \
-  or stable_id match NM_005475 \
-  or stable_id match NM_002834 \
-  or stable_id match NM_004119 \
-  or stable_id match NM_002168 \
-  or stable_id match NM_004380 \
-  or stable_id match NM_000546 \
-  or stable_id match NM_001042492 \
-  or stable_id match NM_012448 \
-  or stable_id match NM_139276 \
-  or stable_id match NM_003620 \
-  or stable_id match NM_001195427 \
-  or stable_id match NM_015559 \
-  or stable_id match NM_004343 \
-  or stable_id match NM_004364 \
-  or stable_id match NM_015338 \
-  or stable_id match NM_080425 \
-  or stable_id match NM_001754 \
-  or stable_id match NM_006758 \
-  or stable_id match NM_007194 \
-  or stable_id match NM_001429 \
-  or stable_id match NM_005089 \
-  or stable_id match NM_001123385 \
-  or stable_id match NM_002049 \
-  or stable_id match NM_001042750 \
-  or stable_id match NM_001184772 \
-  or stable_id match NM_001015877"
-# run vep filtering to remove high AF and outside genelist
-allgenesvepfile="${vcf_prefix}_allgenesvep.vcf"
-docker run -v /home/dnanexus:/opt/vep/.vep \
-  ensemblorg/ensembl-vep:release_103.1 \
-  ./filter_vep -i /opt/vep/.vep/"${allgenesfile}" \
-  -o /opt/vep/.vep/"${allgenesvepfile}" --only_matched --filter \
-  "(gnomAD_AF < 0.10 or not gnomAD_AF)"
+	# find clinvar vcf, remove leading ./
+	clinvar_vcf=$(find ./ -name "clinvar_*.vcf.gz" | sed s'/.\///')
+
+	# find cosmic coding and non-coding vcfs
+	cosmic_coding=$(find ./ -name "CosmicCodingMuts*.vcf.gz" | sed s'/.\///')
+	cosmic_non_coding=$(find ./ -name "CosmicNonCodingVariants*.vcf.gz" | sed s'/.\///')
+
+	# find CADD files, remove leading ./
+	cadd_snv=$(find ./ -name "*SNVs.tsv.gz")
+	cadd_indel=$(find ./ -name "*indel.tsv.gz")
+
+  # find gnomad files, remove leading ./
+  gnomad_genome_vcf=$(find ./ -name "gnomad.genomes.*.vcf.gz" | sed s'/.\///')
+
+	time docker run -v /home/dnanexus:/opt/vep/.vep \
+	ensemblorg/ensembl-vep:release_104.3 \
+	./vep -i /opt/vep/.vep/"${input_vcf}" -o /opt/vep/.vep/"${output_vcf}" \
+	--vcf --cache --refseq --exclude_predicted --symbol --hgvs --af_gnomad \
+	--check_existing --variant_class --numbers \
+	--offline \
+	--custom /opt/vep/.vep/"${clinvar_vcf}",ClinVar,vcf,exact,0,CLNSIG,CLNREVSTAT,CLNDN \
+	--custom /opt/vep/.vep/"${cosmic_coding}",COSMIC,vcf,exact,0,ID \
+	--custom /opt/vep/.vep/"${cosmic_non_coding}",COSMIC,vcf,exact,0,ID \
+  --custom /opt/vep/.vep/"${gnomad_genome_vcf}",gnomADg,vcf,exact,0,AF,AF_AFR,AF_AMR,AF_ASJ,AF_EAS,AF_FIN,AF_NFE,AF_OTH \
+	--plugin CADD,/opt/vep/.vep/"${cadd_snv}",/opt/vep/.vep/"${cadd_indel}" \
+	--fields "$filter_fields" \
+	--no_stats
+}
+
+main() {
+	set -e -x -v -o pipefail
+
+	mark-section "downloading inputs"
+	time dx-download-all-inputs --parallel
+
+	# array inputs end up in subdirectories (i.e. ~/in/array-input/0/), flatten to parent dir
+	find ~/in/vep_plugins -type f -name "*" -print0 | xargs -0 -I {} mv {} ~/in/vep_plugins
+	find ~/in/vep_refs -type f -name "*" -print0 | xargs -0 -I {} mv {} ~/in/vep_refs
+	find ~/in/vep_annotation -type f -name "*" -print0 | xargs -0 -I {} mv {} ~/in/vep_annotation
+
+	# move annotation sources to home
+	mv ~/in/vep_annotation/* /home/dnanexus/
 
 
-mark-section "uploading output"
-mkdir -p ~/out/allgenes_filtered_vcf
-mv ~/"${allgenesvepfile}" ~/out/allgenes_filtered_vcf/
+	mark-section "annotating"
+	
+	# vep needs permissions to write to /home/dnanexus
+	chmod a+rwx /home/dnanexus
+	
+	# extract vep reference annotation tarball to /home/dnanexus
+	time tar xf /home/dnanexus/in/vep_refs/*.tar.gz -C /home/dnanexus
 
-dx-upload-all-outputs --parallel
+	# place fasta and indexes for VEP in the annotation folder
+	mv /home/dnanexus/in/vep_refs/*fa.gz* ~/homo_sapiens_refseq/104_GRCh37/
 
-mark-success
+	# place plugins into plugins folder
+	mkdir ~/Plugins
+	mv ~/in/vep_plugins/* ~/Plugins/
+
+
+	# load vep docker
+	docker load -i "$vep_docker_path"
+
+	mark-section "uploading output"
+
+  # upload output files
+	
+	mark-success
+}


### PR DESCRIPTION
Restructured app to mirror what the vcf handler for uranus is doing with the addition of --exclude_null_alleles flag to exlcude multiple Cosmic IDs for the same variant, changes in the buffer size /form  and the addition of gnomad genomes as custom annotation.

All defaults annotation files suggested in the dxapp.json are for GRCh37.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/eastgenomics/eggd_vep/2)
<!-- Reviewable:end -->
