### PR TITLE
fix VW-110 when no annotations are passed

### DIFF
--- a/src/code.sh
+++ b/src/code.sh
@@ -173,7 +173,14 @@ main() {
 	echo $(date +%T)
 
 	vep_files=$(jq -r '.custom_annotations,.plugins | .[].resource_files[] | .file_id,  (.index_id // empty) ' "$config_file_path")
-	xargs -P"$FORKS" -n1 dx download <<< $vep_files
+
+	# Check if vep_files is empty and skip download
+	if [[ ! -z $vep_files ]];
+	then
+		xargs -P"$FORKS" -n1 dx download <<< $vep_files
+	else
+		echo "No plugins or custom annotation passed."
+	fi
 
 	echo $(date +%T)
 


### PR DESCRIPTION
App failed if no plugins or custom annotation are passed. This has been fixed to allow default vep annotation.

Successful job: https://platform.dnanexus.com/projects/G9Q2B8843VxFBb9Y4j3PJ0g6/monitor/job/G9Q3QV043Vx7qzg5G9x4479J

Test 3 - described here: https://cuhbioinformatics.atlassian.net/wiki/spaces/VW/pages/2605711365/VEP+Config+file

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/eastgenomics/eggd_vep/7)
<!-- Reviewable:end -->
