### PR TITLE
remove --af_gnomad flag

### DIFF
--- a/src/code.sh
+++ b/src/code.sh
@@ -32,7 +32,7 @@ _annotate_vep_vcf () {
 	/usr/bin/time -v docker run -v /home/dnanexus:/opt/vep/.vep \
 	${VEP_IMAGE_ID} \
 	./vep -i /opt/vep/.vep/"${input_vcf}" -o /opt/vep/.vep/"${output_vcf}" \
-	--vcf --cache --refseq --exclude_predicted --symbol --hgvs --af_gnomad \
+	--vcf --cache --refseq --exclude_predicted --symbol --hgvs \
 	--check_existing --variant_class --numbers \
 	--offline --exclude_null_alleles \
 	$ANNOTATION_STRING $PLUGIN_STRING --fields "$fields" \


### PR DESCRIPTION
Remove --af_gnomad flag as we are passing gnomad exomes as custom annotation to extract count information.

Job with updated code and exomes custom annotation running here: https://platform.dnanexus.com/projects/G9Q2B8843VxFBb9Y4j3PJ0g6/monitor/job/G9ZXvyQ43Vx80jg9B4BZvp30

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/eastgenomics/eggd_vep/8)
<!-- Reviewable:end -->
