### PR TITLE
add --format vcf to vep command

### DIFF
--- a/src/code.sh
+++ b/src/code.sh
@@ -35,7 +35,7 @@ _annotate_vep_vcf () {
 	${VEP_IMAGE_ID} \
 	./vep -i /opt/vep/.vep/"${input_vcf}" -o /opt/vep/.vep/"${output_vcf}" \
 	--vcf --cache --refseq --exclude_predicted --symbol --hgvs \
-	--check_existing --variant_class --numbers \
+	--check_existing --variant_class --numbers --format vcf\
 	--offline --exclude_null_alleles --assembly "$assembly_string"\
 	$ANNOTATION_STRING $PLUGIN_STRING --fields "$fields" \
 	 --buffer_size "$buffer_size" --fork "$FORKS" \


### PR DESCRIPTION
VEP app didn't finish successfully do to VEP not picking up the file format from the header rather than the calls so broke with an empty vcf. 

Failed job log: https://platform.dnanexus.com/projects/G9Q2B8843VxFBb9Y4j3PJ0g6/monitor/job/G9kjyzj43VxFpzJp6bJfbpF8
Bug and solution explained in this issue: https://github.com/Ensembl/ensembl-vep/issues/215

Added the --format vcf to the vep command as explained in the issue. 

Job that it completes with an empty vcf: https://platform.dnanexus.com/projects/G9Q2B8843VxFBb9Y4j3PJ0g6/monitor/job/G9kpf9043Vx04K7V8pFXzv4F
Job that it completes normally with a proper vcf: https://platform.dnanexus.com/projects/G9Q2B8843VxFBb9Y4j3PJ0g6/monitor/job/G9kpBx843VxPyqQQKKf87F08

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/eastgenomics/eggd_vep/11)
<!-- Reviewable:end -->
