### PR TITLE
Changes for compatibility with CNV annotation

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -79,6 +79,7 @@ A variable level of annotation can be achieved by different combinations of cust
 - Amount of variants VEP will annotate per core(`buffer_size`) [default = 500] : to allow for parallelisation the app recognises the instance type and splits annotation in the amount of available cores.
 - A panel bed file to filter the vcf on (`panel_bed`)
 - A list of transcripts to filter on (`transcript_list`). One transcript per line. VEP annotates with all possible transcripts and if this list is passed it filters on the given transcript list.
+- A boolean flag of whether to normalise the input vcf or not (`normalise`) [ default=true ].
 
 __This app uses the following tools which are app assets:__
 * htslib (v1.14)
@@ -92,3 +93,4 @@ __This app uses the following tools which are app assets:__
 
 ## Notes
 - This app uses a buffer_size of 500 variants and parallelised the maximum number of cores available. As a default, this app runs using mem1_ssd1_v2_x16 which translates to 16 cores. This was chosen to speed up set up.
+- The default behaviour of this app is to normalise the input vcf as all default annotation used is also normalised to be able to appropriately compare and annotate the vcf. The `normalise` option was built to ensure compatibility with copy-number vcfs which do not require normalisation.

--- a/Readme.md
+++ b/Readme.md
@@ -7,10 +7,10 @@ Annotates a vcf using [Variant Effect Predictor](https://github.com/Ensembl/ense
 ## What are typical use cases for this app?
 This app was designed to annotate vcfs with specified fields based on provided annotation.
 
-A variable level of annotation can be achieved by different combinations of custom annotation , vep plugins in addition to the required VEP cache annotation bundle.
+A variable level of annotation can be achieved by different combinations of custom annotation and vep plugins, in addition to the required VEP cache annotation bundle.
 
 ## What data are required for this app to run?
-- An input vcf to annotate (`vcf`)
+- An input vcf to be annotated (`vcf`)
 - Annotation configuration file (`config_file`):
     - json file providing information about annotations and plugins.
     - Example config file:
@@ -76,19 +76,19 @@ A variable level of annotation can be achieved by different combinations of cust
 
 
 ## What are the optional inputs for this app?
-- Amount of variants VEP will annotate per core(`buffer_size`) [default = 500] : to allow for parallelisation the app recognised the instance type and splits annotation in the amount of available cores.
+- Amount of variants VEP will annotate per core(`buffer_size`) [default = 500] : to allow for parallelisation the app recognises the instance type and splits annotation in the amount of available cores.
 - A panel bed file to filter the vcf on (`panel_bed`)
 - A list of transcripts to filter on (`transcript_list`). One transcript per line. VEP annotates with all possible transcripts and if this list is passed it filters on the given transcript list.
 
-__This app uses the follow tools which are app assets:__
+__This app uses the following tools which are app assets:__
 * htslib (v1.14)
 * bedtools (v2.30.0)
 
 
 
-> For larger vcfs please consider about the appropriate instance type and buffer size to use.
+> For larger vcfs please consider the appropriate instance type and buffer size to use.
 ## What does this app output?
-- Annotated (and filtered if requested) vcf.
+- Annotated (and if requested, filtered) vcf.
 
 ## Notes
-- This app uses a buffer_size of 500 variants and parallelised the maximum number of cores available.As a default this app runs using mem1_ssd1_v2_x16 which translates to 16 cores. This was chosen to speed up set up.
+- This app uses a buffer_size of 500 variants and parallelised the maximum number of cores available. As a default, this app runs using mem1_ssd1_v2_x16 which translates to 16 cores. This was chosen to speed up set up.

--- a/dxapp.json
+++ b/dxapp.json
@@ -1,6 +1,6 @@
 {
-  "name": "eggd_vep",
-  "title": "eggd_vep",
+  "name": "eggd_vep_CNV_dev",
+  "title": "eggd_vep_CNV_dev",
   "summary": "Annotates and filters VCF files",
   "properties": {
     "githubRelease": "1.0.0"
@@ -22,8 +22,8 @@
       "label": "Number of variants to annotate",
       "help": "To make annotating more efficient, the number of variants to annotate can chosen. Default is 500 but can be tweaked for bigger files.",
       "class": "int",
-      "optional": true,
-      "default": 500
+      "default": 500,
+      "optional": true
     },
     {
       "name": "config_file",
@@ -46,6 +46,22 @@
       "label": "List of transcripts to output after annotation.",
       "help": "List of transcripts to output. One transcript per row. If given VEP filters annotated output with given transcript list.",
       "class": "file",
+      "optional": true
+    },
+    {
+      "name": "toNormalise",
+      "label": "whether to normalise variants in VCF",
+      "help": "should NOT be used with CNV vcfs",
+      "class": "boolean",
+      "default": true,
+      "optional": true
+    },
+    {
+      "name": "toCompress",
+      "label": "whether to compress output file",
+      "help": "output an annotated VCF or vcf.gz",
+      "class": "boolean",
+      "default": true,
       "optional": true
     }
   ],

--- a/dxapp.json
+++ b/dxapp.json
@@ -1,9 +1,9 @@
 {
-  "name": "eggd_vep_CNV_dev",
+  "name": "eggd_vep",
   "title": "eggd_vep_CNV_dev",
   "summary": "Annotates and filters VCF files",
   "properties": {
-    "githubRelease": "1.0.0"
+    "githubRelease": "1.0.1"
   },
   "dxapi": "1.0.0",
   "openSource": true,
@@ -50,16 +50,8 @@
     },
     {
       "name": "toNormalise",
-      "label": "whether to normalise variants in VCF",
-      "help": "should NOT be used with CNV vcfs",
-      "class": "boolean",
-      "default": true,
-      "optional": true
-    },
-    {
-      "name": "toCompress",
-      "label": "whether to compress output file",
-      "help": "output an annotated VCF or vcf.gz",
+      "label": "Optional flag dictating whether to normalise input VCF",
+      "help": "Default is true but should NOT be used with CNV vcfs",
       "class": "boolean",
       "default": true,
       "optional": true
@@ -101,7 +93,6 @@
     ]
   },
   "developers":[
-    "user-toutoua",
     "org-emee_1"
   ],
   "authorizedUsers": [

--- a/dxapp.json
+++ b/dxapp.json
@@ -1,6 +1,6 @@
 {
   "name": "eggd_vep",
-  "title": "eggd_vep_CNV_dev",
+  "title": "eggd_vep",
   "summary": "Annotates and filters VCF files",
   "properties": {
     "githubRelease": "1.1.0"

--- a/dxapp.json
+++ b/dxapp.json
@@ -3,11 +3,11 @@
   "title": "eggd_vep_CNV_dev",
   "summary": "Annotates and filters VCF files",
   "properties": {
-    "githubRelease": "1.0.1"
+    "githubRelease": "1.1.0"
   },
   "dxapi": "1.0.0",
   "openSource": true,
-  "version": "1.0.0",
+  "version": "1.1.0",
   "inputSpec": [
     {
       "name": "vcf",

--- a/dxapp.json
+++ b/dxapp.json
@@ -49,7 +49,7 @@
       "optional": true
     },
     {
-      "name": "toNormalise",
+      "name": "normalise",
       "label": "Optional flag dictating whether to normalise input VCF",
       "help": "Default is true but should NOT be used with CNV vcfs",
       "class": "boolean",
@@ -122,8 +122,7 @@
         "author": "EMBL-EBI"
       }
     ],
-    "contactEmail": "East GLH Bioinformatics",
-    "whatsNew": "* 1.0.0 First release of VEP app with modular annotation inputs.\n"
+    "whatsNew": "* 1.1.0 Makes normalisation option & minor typo fixes \n"
   },
   "categories": [],
   "access": {

--- a/src/code.sh
+++ b/src/code.sh
@@ -299,17 +299,9 @@ main() {
 		mv "${vcf_prefix}_temp_annotated.vcf.gz" "${output_vcf}.gz"
 	fi
 
-	# Compress output file, if requested
-    if ! $toCompress;
-	then
-		gzip -d "${output_vcf}.gz"
-		annotated_vcf=$(dx upload ${output_vcf} --brief)
-	else
-		annotated_vcf=$(dx upload "${output_vcf}.gz" --brief)
-	fi
-
 	# Upload output vcf
 	mark-section "uploading output"
+	annotated_vcf=$(dx upload "${output_vcf}.gz" --brief)
 	dx-jobutil-add-output annotated_vcf "$annotated_vcf" --class=file
 
 	mark-success

--- a/src/code.sh
+++ b/src/code.sh
@@ -221,6 +221,9 @@ main() {
 	fi
 
 	# Normalise variants, if applicable
+	# Normalisation is a default option for this app, should only be changed
+	# when running for non-SNV vcfs.
+
     if $toNormalise;
 	then
 		bcftools norm -f genome.fa -m -any --keep-sum AD  "${vcf_prefix}_filtered.vcf" -o "${vcf_prefix}_post_filtering.vcf"

--- a/src/code.sh
+++ b/src/code.sh
@@ -35,10 +35,10 @@ _annotate_vep_vcf () {
 	${VEP_IMAGE_ID} \
 	./vep -i /opt/vep/.vep/"${input_vcf}" -o /opt/vep/.vep/"${output_vcf}" \
 	--vcf --cache --refseq --exclude_predicted --symbol --hgvs \
-	--check_existing --variant_class --numbers --format vcf\
-	--offline --exclude_null_alleles --assembly "$assembly_string"\
+	--check_existing --variant_class --numbers --format vcf \
+	--offline --exclude_null_alleles --assembly "$assembly_string" \
 	$ANNOTATION_STRING $PLUGIN_STRING --fields "$fields" \
-	 --buffer_size "$buffer_size" --fork "$FORKS" \
+	--buffer_size "$buffer_size" --fork "$FORKS" \
 	--no_stats --compress_output bgzip --shift_3prime 1
 }
 

--- a/src/code.sh
+++ b/src/code.sh
@@ -217,7 +217,7 @@ main() {
 
 	else
 		echo "No filtering was applied"
-		cp "${vcf_path}" "${vcf_prefix}_filtered.vcf"
+		mv "${vcf_path}" "${vcf_prefix}_filtered.vcf"
 	fi
 
 	# Normalise variants, if applicable

--- a/src/code.sh
+++ b/src/code.sh
@@ -224,7 +224,7 @@ main() {
 	# Normalisation is a default option for this app, should only be changed
 	# when running for non-SNV vcfs.
 
-    if $toNormalise;
+    if $normalise;
 	then
 		bcftools norm -f genome.fa -m -any --keep-sum AD  "${vcf_prefix}_filtered.vcf" -o "${vcf_prefix}_post_filtering.vcf"
 

--- a/src/code.sh
+++ b/src/code.sh
@@ -34,7 +34,7 @@ _annotate_vep_vcf () {
 	/usr/bin/time -v docker run -v /home/dnanexus:/opt/vep/.vep \
 	${VEP_IMAGE_ID} \
 	./vep -i /opt/vep/.vep/"${input_vcf}" -o /opt/vep/.vep/"${output_vcf}" \
-	--vcf --cache --refseq --exclude_predicted --symbol --hgvs \
+	--vcf --cache --refseq --exclude_predicted --symbol --hgvs --hgvsg \
 	--check_existing --variant_class --numbers --format vcf \
 	--offline --exclude_null_alleles --assembly "$assembly_string" \
 	$ANNOTATION_STRING $PLUGIN_STRING --fields "$fields" \

--- a/src/code.sh
+++ b/src/code.sh
@@ -198,7 +198,7 @@ main() {
 		echo "No plugin files found."
 	fi
 
-	mark-section "pre-annotation filtering & normalisation"
+	mark-section "pre-annotation filtering (& normalisation)"
 
 	# Unpack fasta reference
 	tar xzf $ref_bcftools
@@ -223,11 +223,11 @@ main() {
 	# Normalise variants, if applicable
     if $toNormalise;
 	then
-		bcftools norm -f genome.fa -m -any --keep-sum AD -o "${vcf_prefix}_normalised.vcf" "${vcf_prefix}_filtered.vcf"
+		bcftools norm -f genome.fa -m -any --keep-sum AD  "${vcf_prefix}_filtered.vcf" -o "${vcf_prefix}_post_filtering.vcf"
 
 	else
 		echo "No normalisation was applied"
-		mv "${vcf_prefix}_filtered.vcf" "${vcf_prefix}_normalised.vcf"
+		mv "${vcf_prefix}_filtered.vcf" "${vcf_prefix}_post_filtering.vcf"
 	fi
 
 	# If hard filters are passed in the config apply them.
@@ -237,10 +237,10 @@ main() {
 	if test -z "$filter_command" || [ $filter_command == "null" ]
 	then
 		echo "No filtering commands passed."
-		mv "${vcf_prefix}_normalised.vcf" "${vcf_prefix}_temp.vcf"
+		mv "${vcf_prefix}_post_filtering.vcf" "${vcf_prefix}_temp.vcf"
 	else
 		echo "Filter commands passed: $filter_command"
-		eval $(echo ${filter_command} "${vcf_prefix}_normalised.vcf" -o "${vcf_prefix}_temp.vcf")
+		eval $(echo ${filter_command} "${vcf_prefix}_post_filtering.vcf" -o "${vcf_prefix}_temp.vcf")
 	fi
 
 	mark-section "annotating"


### PR DESCRIPTION
This resolves #12 and #13 to accomodate CNVs.

Main change is the addition of the optional flag  `toNormalise` which is set to true as default but not compatible with CNV calling.
Minor changes to edit comments and correct typos also included.

Example jobs:
* this works for CNVs: https://platform.dnanexus.com/projects/G8x02384xVp3Qvj73P3ZxKjK/monitor/job/GFBgPY84xVp6pXPq3ZgV6493 
* this works for CNVs + filtering: https://platform.dnanexus.com/projects/G8x02384xVp3Qvj73P3ZxKjK/monitor/job/GFBk15j4xVp7JpgkG96ZY827
* this still works for SNVs and normalisation works as expected: https://platform.dnanexus.com/projects/G8x02384xVp3Qvj73P3ZxKjK/monitor/job/GFBjYj84xVp3pV9G6Xq8Fxg2

```
# diff of output of original job and output of rerun using same inputs with new app version
diff <(dx cat project-GF62QG045V8k6qX5F5gXXJV7:file-GF7xZ0841V0zQg3BKJJY0j4q| zcat) <(dx cat project-G8x02384xVp3Qvj73P3ZxKjK:file-GFBjqv049F6jg3139Fp3V3b8|zcat)
118,119c118,119
< ##bcftools_normCommand=norm -f genome.fa -m -any --keep-sum AD -o X221668-GM1915714-1-CEN-F-EGG5_markdup_recalibrated_Haplotyper_normalised.vcf -; Date=Thu Jul 14 08:52:55 2022
< ##VEP="v105" time="2022-07-14 08:55:19" cache="/opt/vep/.vep/homo_sapiens_refseq/105_GRCh37" ensembl=105.f357e33 ensembl-io=105.2a0a40c ensembl-variation=105.ac8178e ensembl-funcgen=105.660df8f 1000genomes="phase3" COSMIC="92" ClinVar="202012" HGMD-PUBLIC="20204" assembly="GRCh37.p13" dbSNP="154" gencode="GENCODE 19" genebuild="2011-04" gnomAD="r2.1" polyphen="2.2.2" refseq="2020-10-26 17:03:42 - GCF_000001405.25_GRCh37.p13_genomic.gff" regbuild="1.0" sift="sift5.2.2"
---
> ##bcftools_normCommand=norm -f genome.fa -m -any --keep-sum AD -o X221668-GM1915714-1-CEN-F-EGG5_markdup_recalibrated_Haplotyper_post_filtering.vcf X221668-GM1915714-1-CEN-F-EGG5_markdup_recalibrated_Haplotyper_filtered.vcf; Date=Mon Jul 18 16:42:11 2022
> ##VEP="v105" time="2022-07-18 16:44:24" cache="/opt/vep/.vep/homo_sapiens_refseq/105_GRCh37" ensembl=105.f357e33 ensembl-variation=105.ac8178e ensembl-io=105.2a0a40c ensembl-funcgen=105.660df8f 1000genomes="phase3" COSMIC="92" ClinVar="202012" HGMD-PUBLIC="20204" assembly="GRCh37.p13" dbSNP="154" gencode="GENCODE 19" genebuild="2011-04" gnomAD="r2.1" polyphen="2.2.2" refseq="2020-10-26 17:03:42 - GCF_000001405.25_GRCh37.p13_genomic.gff" regbuild="1.0" sift="sift5.2.2"
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/eastgenomics/eggd_vep/17)
<!-- Reviewable:end -->
